### PR TITLE
Optimized increment and decrement

### DIFF
--- a/arcanevm/number.py
+++ b/arcanevm/number.py
@@ -107,6 +107,29 @@ class Number(object):
             borrow = (~bit_1 & borrow) + (~bit_1 & bit_2) + (bit_2 & borrow) # Figure out this borrow 
 
         return Number(output)
+
+    def increment(self):
+        carry = Number(utils.one.bit_array)
+        output = []
+
+        for bit_i in range(len(self.bit_array))[::-1]:
+            bit_1 = Number(self.bit_array[bit_i])
+            output.append((bit_1 ^ carry).bit_array[0])
+            carry = bit_1 & carry
+
+        return Number(output[::-1])
+
+    def decrement(self):
+        borrow = Number(utils.one.bit_array)
+        output = []
+
+        for bit_i in range(len(self.bit_array))[::-1]:
+            bit_1 = Number(self.bit_array[bit_i])
+            output.append((bit_1 ^ borrow).bit_array[0])
+            borrow = ~bit_1 & borrow
+
+        return Number(output[::-1])
+
     def __mul__(self, num):
         raise NotImplemented("Multiply not yet implemented")
 

--- a/arcanevm/run_tests.py
+++ b/arcanevm/run_tests.py
@@ -14,6 +14,8 @@ def test_suite():
     suite.addTest(TestNumber("test_add"))
     suite.addTest(TestNumber("test_from_plaintext"))
     suite.addTest(TestNumber("test_decrypt"))
+    suite.addTest(TestNumber("test_increment"))
+    suite.addTest(TestNumber("test_decrement"))
     
     suite.addTest(TestTape("test_create_tape"))
     suite.addTest(TestTape("test_add_cell"))

--- a/arcanevm/testcases/test_number.py
+++ b/arcanevm/testcases/test_number.py
@@ -74,6 +74,25 @@ class TestNumber(unittest.TestCase):
         assert(three_plus_two.decrypt(self.context, self.sk, decimal=True) == 5)
         assert(three_plus_three.decrypt(self.context, self.sk, decimal=True) == 6)
 
+    def test_increment(self):
+        zero_inc = self.zero.increment()
+        one_inc = self.one.increment()
+        two_inc = self.two.increment()
+        three_inc = self.three.increment()
+
+        self.assertEqual(zero_inc.decrypt(self.context, self.sk, decimal=True), 1)
+        self.assertEqual(one_inc.decrypt(self.context, self.sk, decimal=True), 2)
+        self.assertEqual(two_inc.decrypt(self.context, self.sk, decimal=True), 3)
+        self.assertEqual(three_inc.decrypt(self.context, self.sk, decimal=True), 4)
+
+    def test_decrement(self):
+        one_dec = self.one.decrement()
+        two_dec = self.two.decrement()
+        three_dec = self.three.decrement()
+
+        self.assertEqual(one_dec.decrypt(self.context, self.sk, decimal=True), 0)
+        self.assertEqual(two_dec.decrypt(self.context, self.sk, decimal=True), 1)
+        self.assertEqual(three_dec.decrypt(self.context, self.sk, decimal=True), 2)
 
     def test_from_plaintext(self):
         one28 = Number.from_plaintext(128, self.context, self.sk)

--- a/arcanevm/testcases/test_number.py
+++ b/arcanevm/testcases/test_number.py
@@ -14,8 +14,8 @@ class TestNumber(unittest.TestCase):
         self.three = Number.from_plaintext(3, self.context, self.sk)
         self.zero = Number.from_plaintext(0, self.context, self.sk)
 
-        utils.zero = self.zero
-        utils.one = self.one
+        utils.zero = Number.from_plaintext(0, self.context, self.sk, size=1)
+        utils.one = Number.from_plaintext(1, self.context, self.sk, size=1)
 
     def test_binary(self):
         one = Number.create_binary_array(1, 8)


### PR DESCRIPTION
Adds and tests increment and decrement methods that should be significantly faster than adding one, on account of requiring less gates per bit computed. Also fixes a bug in the number test setup function in which `utils.one` and `utils.zero` were getting set to 8-bit numbers instead of 1-bit numbers. This was causing tests to both take longer than necessary, and to fail.