### PR TITLE
Autodetect tests

### DIFF
--- a/arcanevm/run_tests.py
+++ b/arcanevm/run_tests.py
@@ -1,30 +1,19 @@
 import unittest
-from testcases.test_number import TestNumber
-from testcases.test_tape import TestTape
-from testcases.test_vm import TestVirtualMachine
+import os
+import sys
 
-def test_suite():
-    suite = unittest.TestSuite()
-    
-    suite.addTest(TestNumber("test_binary"))
-    suite.addTest(TestNumber("test_and"))
-    suite.addTest(TestNumber("test_or"))
-    suite.addTest(TestNumber("test_xor"))
-    suite.addTest(TestNumber("test_not"))
-    suite.addTest(TestNumber("test_mux"))
-    suite.addTest(TestNumber("test_add"))
-    suite.addTest(TestNumber("test_from_plaintext"))
-    suite.addTest(TestNumber("test_decrypt"))
-    suite.addTest(TestNumber("test_increment"))
-    suite.addTest(TestNumber("test_decrement"))
-    
-    suite.addTest(TestTape("test_create_tape"))
-    suite.addTest(TestTape("test_add_cell"))
-
-    suite.addTest(TestVirtualMachine("test_machine_step"))
-
-    return suite
+def discover_recursive(suit, path):
+    for i in os.listdir(path):
+        sub = path + os.path.sep + i
+        if os.path.isdir(sub):
+            if os.path.basename(sub) == 'testcases':
+                suite.addTest(unittest.TestLoader().discover(sub))
+            else:
+                discover_recursive(suit, sub)
 
 if __name__ == "__main__":
+    suite = unittest.TestSuite()
+    discover_recursive(suite, os.path.dirname(sys.argv[0]))
     runner = unittest.TextTestRunner()
-    runner.run(test_suite())
+    result = runner.run(suite)
+    exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION
This causes the `run_tests.py` script to autodetect all tests in the `testcases` directory. I pulled it from another project. I'm not sure if this is what you want to do, but manually copying every test into a file seems tedious, and it's easy to not realize you missed one.